### PR TITLE
Added information about error handling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
-If experiencing **errors** (`error:03000086:digital envelope` for example)
+If experiencing **errors** (e.g. `error:03000086:digital envelope`, `ERR_OSSL_EVP_UNSUPPORTED`) \
 after `npm start` try uninstalling node.js and installing \
-the **Current** version (as of 19.02.2023 v19.6.1)
+the **Current** version (as of 19.02.2023 v19.6.1) \
+If still not working try applying `npm audit fix --force`.
 
 ### `npm run build`
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
-If experiencing errors after `npm start` try uninstalling node.js \
-and installing the Current version (as of 17.02.2023 v19.6.1)
+If experiencing **errors** (error:03000086:digital envelope [reason for this error][(http://localhost:3000)for example](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported#:~:text=Danger,security%20threats.)) \
+after `npm start` try uninstalling node.js \
+and installing the **Current** version (as of 19.02.2023 v19.6.1)
 
 ### `npm run build`
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
+If experiencing errors after `npm start` try uninstalling node.js
+and installing the Current version (as of 17.02.2023 v19.6.1)
+
 ### `npm run build`
 
 Builds the app for production to the `build` folder.\

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
-If experiencing **errors** (error:03000086:digital envelope [reason for this error][(http://localhost:3000)for example](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported#:~:text=Danger,security%20threats.)) \
-after `npm start` try uninstalling node.js \
-and installing the **Current** version (as of 19.02.2023 v19.6.1)
+If experiencing **errors** (`error:03000086:digital envelope` for example)
+after `npm start` try uninstalling node.js and installing \
+the **Current** version (as of 19.02.2023 v19.6.1)
 
 ### `npm run build`
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
-If experiencing errors after `npm start` try uninstalling node.js
+If experiencing errors after `npm start` try uninstalling node.js \
 and installing the Current version (as of 17.02.2023 v19.6.1)
 
 ### `npm run build`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You may also see any lint errors in the console.
 If experiencing **errors** (e.g. `error:03000086:digital envelope`, `ERR_OSSL_EVP_UNSUPPORTED`) \
 after `npm start` try uninstalling node.js and installing \
 the **Current** version (as of 19.02.2023 v19.6.1) \
-If still not working try applying `npm audit fix --force`.
+If still not working try applying `npm audit fix --force`
 
 ### `npm run build`
 


### PR DESCRIPTION
These are the steps that fixed my problem. It says in the README.md file that we should install LTS version of node.js (v18.14.1) but for some reason that did not work for me. Here is a link to explanations regarding the error messages that I faced while using v18.14.1 [explanations](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported). I wasn't sure if I should include this in the readme.md and that's why I'm posting it here.