### PR TITLE
Add proxy to events request

### DIFF
--- a/src/components/EventsComponents/EventsMain.js
+++ b/src/components/EventsComponents/EventsMain.js
@@ -62,7 +62,7 @@ const EventsMain = () => {
 		let response = null
 		try {
 			let request = await fetch(
-				`https://ue-varna.bg/bg/eventsfeed?start=${formatStartDate}+02:00&end=${formatEndDate}+03:00`,
+				`https://cryptic-wildwood-52177.herokuapp.com/https://ue-varna.bg/bg/eventsfeed?start=${formatStartDate}+02:00&end=${formatEndDate}+03:00`,
 				{
 					method: 'GET',
 				}


### PR DESCRIPTION
Prepend a proxy URL to the requested one so we bypass the cors errors.

The URL proxy is based on this repo: https://github.com/Rob--W/cors-anywhere